### PR TITLE
Update QoaDecoder to stream from std::io::Read

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "qoaudio-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.qoaudio]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "iter_all"
+path = "fuzz_targets/iter_all.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/iter_all.rs
+++ b/fuzz/fuzz_targets/iter_all.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(decoder) = qoaudio::QoaDecoder::new(std::io::Cursor::new(data)) else {
+        return
+    };
+    decoder.take_while(|i| matches!(i, Ok(_))).count();
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,7 @@ impl QoaDecoder<std::io::BufReader<std::fs::File>> {
 }
 
 /// Return type of [`QoaDecoder::next`].
+#[derive(Debug)]
 pub enum QoaItem {
     Sample(i16),
     FrameHeader(FrameHeader),


### PR DESCRIPTION
Instead of requiring all input bytes and all output bytes to be in
memory simultaneously, stream the input from a std::io::Read and
allow the output to be retrieved sample by sample. This reduces memory
consumption from O(2*N) to O(1) with regards to file size. Samples are
decoded one slice at a time and stored so the fixed memory overhead is
40 bytes per channel.

This is a large API breaking change. Since an IO error can occur while
decoding a new IoError variant is introduced and some existing variants
are replaced by the UnexpectedEoF error kind of io::Error.

Resolves #1 
