### PR TITLE
Add benchmark and improve performance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/target
 Cargo.lock
+/perf.data
 
 # Editor directories and files
 .idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/rafaelcaricio/qoaudio"
 [dependencies]
 rodio = { version = "0.17.1", default-features = false, optional = true }
 
+[dev-dependencies]
+criterion = "0.3"
+
 [features]
 default = []
 
@@ -18,3 +21,7 @@ default = []
 name = "play"
 path = "examples/play.rs"
 required-features = ["rodio"]
+
+[[bench]]
+name = "qoa_benchmarks"
+harness = false

--- a/benches/qoa_benchmarks.rs
+++ b/benches/qoa_benchmarks.rs
@@ -1,0 +1,19 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+static QOA_BYTES: &[u8] = include_bytes!("../fixtures/julien_baker_sprained_ankle.qoa");
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("iter_sprained_ankle", |b| {
+        b.iter(|| {
+            let Ok(decoder) = qoaudio::QoaDecoder::new(std::io::Cursor::new(QOA_BYTES)) else {
+                panic!("QoaDecoder::new failed");
+            };
+            let count = decoder.take_while(|i| matches!(i, Ok(_))).count();
+            assert_eq!(count, 2394122 * 2 + 468);
+            black_box(count);
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
On my computer[1] the benchmark took 56ms before the other changes. Forcing inline on the two functions called in the inner loop dropped it down to 38ms. Restructuring the code so the inner loop is always 20 brought it down to 30ms.

[1] i7-1165G7 (8) @ 4.700GHz with 32 GB ram running Arch Linux