### PR TITLE
Expose rodio feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ criterion = "0.3"
 
 [features]
 default = []
+rodio = ["dep:rodio"]
 
 [[example]]
 name = "play"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ criterion = "0.3"
 
 [features]
 default = []
-rodio = ["dep:rodio"]
+rodio = ["rodio"]
 
 [[example]]
 name = "play"


### PR DESCRIPTION
Just a quick expose of the feature, so that external crates can rely on the rodio integration.
